### PR TITLE
Remove redundant header navigation from codex pages

### DIFF
--- a/docs/codex/faction-ashborne.html
+++ b/docs/codex/faction-ashborne.html
@@ -72,63 +72,10 @@
         }
 
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="factions.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/faction-atlantean.html
+++ b/docs/codex/faction-atlantean.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .atlantean-glow {
+.atlantean-glow {
             background: linear-gradient(135deg, rgba(0, 128, 128, 0.1) 0%, rgba(0, 64, 64, 0.2) 100%);
             border-left: 4px solid #008b8b;
             padding: 1.5rem;
@@ -117,21 +77,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background:
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-bloodlines.html
+++ b/docs/codex/faction-bloodlines.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Bloodlines-specific glow boxes (blood red theme) */
+/* Bloodlines-specific glow boxes (blood red theme) */
         .bloodlines-glow {
             background: linear-gradient(135deg, rgba(139, 0, 0, 0.1) 0%, rgba(178, 34, 34, 0.2) 100%);
             border-left: 4px solid #8b0000;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-church.html
+++ b/docs/codex/faction-church.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none; /* Hidden by default, shown by JS if not in iframe */
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Church-specific glow boxes (gold/divine theme) */
+/* Church-specific glow boxes (gold/divine theme) */
         .church-glow {
             background: linear-gradient(135deg, rgba(218, 165, 32, 0.1) 0%, rgba(184, 134, 11, 0.2) 100%);
             border-left: 4px solid #daa520;
@@ -118,26 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-church.html">Church</a>
-            <a href="faction-dwarves.html">Dwarves</a>
-            <a href="faction-undead.html">Ossuarium</a>
-            <a href="faction-elves.html">Elves</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Darker Aged Parchment Background -->
+<!-- Faction Header with Darker Aged Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-crucible.html
+++ b/docs/codex/faction-crucible.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Crucible-specific glow boxes (steel blue/industrial theme) */
+/* Crucible-specific glow boxes (steel blue/industrial theme) */
         .crucible-glow {
             background: linear-gradient(135deg, rgba(70, 130, 180, 0.1) 0%, rgba(100, 149, 237, 0.2) 100%);
             border-left: 4px solid #4682b4;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Darker Aged Parchment Background -->
+<!-- Faction Header with Darker Aged Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-draconid.html
+++ b/docs/codex/faction-draconid.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Draconid-specific glow boxes */
+/* Draconid-specific glow boxes */
         .draconid-glow {
             background: linear-gradient(135deg, rgba(138, 43, 226, 0.1) 0%, rgba(75, 0, 130, 0.2) 100%);
             border-left: 4px solid #8a2be2;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-dwarves.html
+++ b/docs/codex/faction-dwarves.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Dwarven-specific glow boxes (stone gray/earth theme) */
+/* Dwarven-specific glow boxes (stone gray/earth theme) */
         .dwarven-glow {
             background: linear-gradient(135deg, rgba(105, 105, 105, 0.1) 0%, rgba(128, 128, 128, 0.2) 100%);
             border-left: 4px solid #696969;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-elves.html
+++ b/docs/codex/faction-elves.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Elven-specific glow boxes (nature green theme) */
+/* Elven-specific glow boxes (nature green theme) */
         .elven-glow {
             background: linear-gradient(135deg, rgba(34, 139, 34, 0.1) 0%, rgba(60, 179, 113, 0.2) 100%);
             border-left: 4px solid #228b22;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-emergent.html
+++ b/docs/codex/faction-emergent.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Emergent-specific glow boxes (electric blue/void theme) */
+/* Emergent-specific glow boxes (electric blue/void theme) */
         .emergent-glow {
             background: linear-gradient(135deg, rgba(0, 191, 255, 0.1) 0%, rgba(30, 144, 255, 0.2) 100%);
             border-left: 4px solid #00bfff;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-exchange.html
+++ b/docs/codex/faction-exchange.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Exchange-specific glow boxes (merchant crimson/gold theme) */
+/* Exchange-specific glow boxes (merchant crimson/gold theme) */
         .exchange-glow {
             background: linear-gradient(135deg, rgba(220, 20, 60, 0.1) 0%, rgba(178, 34, 34, 0.2) 100%);
             border-left: 4px solid #dc143c;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Darker Aged Parchment Background -->
+<!-- Faction Header with Darker Aged Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-fae.html
+++ b/docs/codex/faction-fae.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Wyrd Conclave-specific glow boxes (mystical purple/pink theme) */
+/* Wyrd Conclave-specific glow boxes (mystical purple/pink theme) */
         .wyrd-glow {
             background: linear-gradient(135deg, rgba(186, 85, 211, 0.1) 0%, rgba(147, 112, 219, 0.2) 100%);
             border-left: 4px solid #ba55d3;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Darker Aged Parchment Background -->
+<!-- Faction Header with Darker Aged Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-nomads.html
+++ b/docs/codex/faction-nomads.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Nomad-specific glow boxes (desert orange/gold theme) */
+/* Nomad-specific glow boxes (desert orange/gold theme) */
         .nomad-glow {
             background: linear-gradient(135deg, rgba(255, 140, 0, 0.1) 0%, rgba(218, 165, 32, 0.2) 100%);
             border-left: 4px solid #ff8c00;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/faction-undead.html
+++ b/docs/codex/faction-undead.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Ossuarium-specific glow boxes (dark green/bone theme) */
+/* Ossuarium-specific glow boxes (dark green/bone theme) */
         .ossuarium-glow {
             background: linear-gradient(135deg, rgba(34, 139, 34, 0.1) 0%, rgba(0, 100, 0, 0.2) 100%);
             border-left: 4px solid #228b22;
@@ -118,21 +78,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- Faction Header with Parchment Background -->
+<!-- Faction Header with Parchment Background -->
     <div style="background: 
     var(--leather-texture),
     repeating-linear-gradient(

--- a/docs/codex/lore-atlantis-return.html
+++ b/docs/codex/lore-atlantis-return.html
@@ -6,52 +6,7 @@
     <title>The Atlantean Emergence - Penance Codex</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .atlantean-glow {
+.atlantean-glow {
             background: linear-gradient(135deg, rgba(0, 128, 128, 0.1) 0%, rgba(0, 64, 64, 0.2) 100%);
             border-left: 4px solid #008b8b;
             padding: 1.5rem;

--- a/docs/codex/tables-anomalous-events.html
+++ b/docs/codex/tables-anomalous-events.html
@@ -6,47 +6,7 @@
     <title>Anomalous Event Tables - Penance Codex</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Tier-specific glow boxes */
+/* Tier-specific glow boxes */
         .tier-sanctus {
             background: linear-gradient(135deg, rgba(218, 165, 32, 0.1) 0%, rgba(184, 134, 11, 0.15) 100%);
             border-left: 4px solid #daa520;
@@ -152,19 +112,6 @@
     </style>
 </head>
 <body>
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
     <main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /


### PR DESCRIPTION
Removed duplicate navigation elements that were redundant with breadcrumb navigation:
- Removed "← Return to Codex | Home" navigation bar and associated elements
- Removed JavaScript that conditionally displays navigation
- Cleaned up CSS styling (removed .codex-nav and related classes)

The breadcrumb navigation (CODEX / Category / File) already provides this functionality, so the header navigation was unnecessary duplication.

Files cleaned:
- All faction pages (13 files: faction-*.html)
- lore-atlantis-return.html
- tables-anomalous-events.html

Result: Cleaner page headers with single navigation method (breadcrumbs only)