### PR TITLE
Complete removal of all redundant 'Return to Codex' navigation elements

### DIFF
--- a/docs/codex/balance-v529-final.html
+++ b/docs/codex/balance-v529-final.html
@@ -118,105 +118,11 @@
             font-weight: 700;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/bloodlines_mechanic.html
+++ b/docs/codex/bloodlines_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-bloodlines.html">Bloodlines Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-bloodlines.html" target="_parent">BLOODLINES</a> /

--- a/docs/codex/campaign-anomalous-events.html
+++ b/docs/codex/campaign-anomalous-events.html
@@ -145,105 +145,11 @@
             line-height: 1.4;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-event-tables.html
+++ b/docs/codex/campaign-event-tables.html
@@ -133,105 +133,11 @@
             font-weight: bold;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-flesh-bargains.html
+++ b/docs/codex/campaign-flesh-bargains.html
@@ -131,105 +131,11 @@
             font-weight: bold;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-loot-tables.html
+++ b/docs/codex/campaign-loot-tables.html
@@ -156,105 +156,11 @@
             color: #fff;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-mission-generation.html
+++ b/docs/codex/campaign-mission-generation.html
@@ -248,106 +248,12 @@
             letter-spacing: 0.05em;
             font-weight: 700;
         }
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
+            
 
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /
@@ -925,8 +831,7 @@
                 <a href="enemies-bestiary.html" target="_parent" style="color: var(--aged-gold); text-decoration: none; margin-right: 2rem;">→ Core Bestiary</a>
                 <a href="enemies-anomalous.html" target="_parent" style="color: var(--aged-gold); text-decoration: none; margin-right: 2rem;">→ Anomalous Bestiary</a>
                 <a href="campaign-settlement-phase.html" target="_parent" style="color: var(--aged-gold); text-decoration: none; margin-right: 2rem;">→ Settlement Phase</a>
-                <a href="content-home.html" target="_parent" style="color: var(--aged-gold); text-decoration: none;">← Return to Codex</a>
-            </p>
+                </p>
         </div>
 
         <div style="background: var(--shadow-black); border: 3px double #660000; padding: 2rem; margin: 3rem 0; font-style: italic; text-align: center;">

--- a/docs/codex/campaign-pilot-generation.html
+++ b/docs/codex/campaign-pilot-generation.html
@@ -18,105 +18,11 @@
             background: linear-gradient(to bottom, #8b6914, #6b5310) !important;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-pilot-grit.html
+++ b/docs/codex/campaign-pilot-grit.html
@@ -21,105 +21,11 @@
             background: linear-gradient(to bottom, #8b6914, #6b5310) !important;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="#v3-optional">v3.0 OPTIONAL</a> /

--- a/docs/codex/campaign-pilot-progression.html
+++ b/docs/codex/campaign-pilot-progression.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-pilot-skills.html
+++ b/docs/codex/campaign-pilot-skills.html
@@ -125,105 +125,11 @@
             color: var(--blood-red);
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-scavengers-crusade.html
+++ b/docs/codex/campaign-scavengers-crusade.html
@@ -153,105 +153,11 @@
             color: #fff;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-settlement-phase.html
+++ b/docs/codex/campaign-settlement-phase.html
@@ -63,105 +63,11 @@
  margin-bottom: 1rem;
  }
          /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="content" role="main">
+<main class="content" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign-settlements.html
+++ b/docs/codex/campaign-settlements.html
@@ -153,105 +153,11 @@
             margin: 0.5rem 0;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/campaign.html
+++ b/docs/codex/campaign.html
@@ -6,52 +6,7 @@
     <title>Campaign Index - Penance Codex</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .campaign-grid {
+.campaign-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 2rem;
@@ -105,20 +60,7 @@
     </style>
 </head>
 <body>
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="index.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             Campaign Index

--- a/docs/codex/card-anatomy.html
+++ b/docs/codex/card-anatomy.html
@@ -70,65 +70,11 @@
             background: linear-gradient(135deg, #6b1a1a, #4a0e0e);
             box-shadow: 0 0 15px rgba(184, 149, 106, 0.5);
         }
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+            
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <div class="breadcrumb" style="position: fixed; top: 10px; left: 10px; background: rgba(26,20,16,0.9); padding: 0.5rem 1rem; border-radius: 4px; z-index: 1000;">
+<div class="breadcrumb" style="position: fixed; top: 10px; left: 10px; background: rgba(26,20,16,0.9); padding: 0.5rem 1rem; border-radius: 4px; z-index: 1000;">
     <a href="content-home.html" target="_parent" style="color: #d4c5b0; text-decoration: none;">CODEX</a> /
     <a href="#rules" style="color: #d4c5b0; text-decoration: none;">RULES</a> /
     <span style="color: #b8956a;">Card Anatomy</span>
@@ -415,11 +361,7 @@
                 <strong>9. Border:</strong> Gold standard border. Potential variants: Silver (rare), Red (legendary), or faction-specific colors.
             </div>
         </div>
-
-        <div style="text-align: center; margin-top: 2rem;">
-            <a href="index.html" class="back-link">← Return to Codex</a>
-        </div>
-    </div>
+</div>
     <script src="codex-common.js"></script>
 </body>
 </html>

--- a/docs/codex/church_mechanic.html
+++ b/docs/codex/church_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-church.html">Church Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-church.html" target="_parent">CHURCH</a> /

--- a/docs/codex/cosmology.html
+++ b/docs/codex/cosmology.html
@@ -21,52 +21,7 @@
         }
 
         /* Navigation bar */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Hero Section with Parallax */
+/* Hero Section with Parallax */
         .hero-section {
             position: relative;
             min-height: 60vh;
@@ -485,17 +440,7 @@
 <body>
     <!-- Scroll Progress Bar -->
     <div class="scroll-progress" id="scrollProgress"></div>
-
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/crucible_mechanic.html
+++ b/docs/codex/crucible_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-crucible.html">Crucible Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-crucible.html" target="_parent">CRUCIBLE</a> /

--- a/docs/codex/dwarves_mechanic.html
+++ b/docs/codex/dwarves_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-dwarves.html">Dwarves Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-dwarves.html" target="_parent">DWARVES</a> /

--- a/docs/codex/elves_mechanic.html
+++ b/docs/codex/elves_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-elves.html">Elves Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-elves.html" target="_parent">ELVES</a> /

--- a/docs/codex/emergent_mechanic.html
+++ b/docs/codex/emergent_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-emergent.html">Emergent Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-emergent.html" target="_parent">EMERGENT</a> /

--- a/docs/codex/enemies-anomalous.html
+++ b/docs/codex/enemies-anomalous.html
@@ -80,105 +80,11 @@
             margin-top: 1rem;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="#enemies">ENEMIES</a> /

--- a/docs/codex/enemies-bestiary.html
+++ b/docs/codex/enemies-bestiary.html
@@ -83,105 +83,11 @@
             margin-bottom: 1.5rem;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/equipment-decks.html
+++ b/docs/codex/equipment-decks.html
@@ -6,106 +6,12 @@
     <title>Equipment & Deck Building (Retired) - Penance</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
+        
 
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="#equipment">EQUIPMENT</a> /
@@ -348,13 +254,7 @@
         </table>
 
         <div class="section-break"></div>
-
-        <!-- Navigation breadcrumbs -->
-        <p style="margin-top: 3rem; font-size: 0.9rem; opacity: 0.7; text-align: center;">
-            <a href="#" onclick="parent.loadContent('content-home.html'); return false;" style="color: var(--dark-red);">← Return to Codex Home</a>
-        </p>
-
-        <p style="font-style: italic; text-align: center; margin-top: 2rem; opacity: 0.8; font-size: 0.95rem;">
+<p style="font-style: italic; text-align: center; margin-top: 2rem; opacity: 0.8; font-size: 0.95rem;">
             "Your deck is your arsenal. Craft wisely. Fight brutally. Smelt the obsolete. Forge your legend in iron and blood."
         </p>
     </div>

--- a/docs/codex/exchange_mechanic.html
+++ b/docs/codex/exchange_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-exchange.html">Exchange Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-exchange.html" target="_parent">EXCHANGE</a> /

--- a/docs/codex/factions.html
+++ b/docs/codex/factions.html
@@ -6,52 +6,7 @@
     <title>Factions Index - Penance Codex</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .faction-grid {
+.faction-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 1.5rem;
@@ -97,20 +52,7 @@
     </style>
 </head>
 <body>
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="index.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             Factions Index

--- a/docs/codex/gm-helper.html
+++ b/docs/codex/gm-helper.html
@@ -55,105 +55,11 @@
             font-size: 0.9rem;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="content-home.html" target="_parent">Codex Home</a> &raquo; Resources &raquo; GM Helper
         </nav>

--- a/docs/codex/gm-reference-combat.html
+++ b/docs/codex/gm-reference-combat.html
@@ -81,105 +81,11 @@
             color: var(--aged-gold);
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/lore-atlantis-return.html
+++ b/docs/codex/lore-atlantis-return.html
@@ -67,20 +67,7 @@
     </style>
 </head>
 <body>
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="index.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-bloodlines-culture.html
+++ b/docs/codex/lore-bloodlines-culture.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-bonelord-karath.html
+++ b/docs/codex/lore-bonelord-karath.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-casket-manufacturing.html
+++ b/docs/codex/lore-casket-manufacturing.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-casket-origins.html
+++ b/docs/codex/lore-casket-origins.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-caskets-overview.html
+++ b/docs/codex/lore-caskets-overview.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-chronicle.html
+++ b/docs/codex/lore-chronicle.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-climate.html
+++ b/docs/codex/lore-climate.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-crucible-culture.html
+++ b/docs/codex/lore-crucible-culture.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-daily-life.html
+++ b/docs/codex/lore-daily-life.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-draconid-history.html
+++ b/docs/codex/lore-draconid-history.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-emergent-culture.html
+++ b/docs/codex/lore-emergent-culture.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-engine.html
+++ b/docs/codex/lore-engine.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-factions-overview.html
+++ b/docs/codex/lore-factions-overview.html
@@ -390,105 +390,11 @@
             box-shadow: 0 0 10px rgba(212, 175, 55, 0.3);
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-ground-zero.html
+++ b/docs/codex/lore-ground-zero.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-magic-systems.html
+++ b/docs/codex/lore-magic-systems.html
@@ -8,64 +8,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-neural-threads.html
+++ b/docs/codex/lore-neural-threads.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-npc-bloodlines.html
+++ b/docs/codex/lore-npc-bloodlines.html
@@ -19,105 +19,11 @@
         .npc-description { line-height: 1.7; opacity: 0.95; }
         .npc-quote { background: rgba(139, 0, 0, 0.1); border-left: 3px solid #8B0000; padding: 1rem; margin: 1rem 0; font-style: italic; opacity: 0.9; }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-church.html
+++ b/docs/codex/lore-npc-church.html
@@ -76,64 +76,10 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-crucible.html
+++ b/docs/codex/lore-npc-crucible.html
@@ -19,105 +19,11 @@
         .npc-description { line-height: 1.7; opacity: 0.95; }
         .npc-quote { background: rgba(210, 105, 30, 0.1); border-left: 3px solid #D2691E; padding: 1rem; margin: 1rem 0; font-style: italic; opacity: 0.9; }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-draconid.html
+++ b/docs/codex/lore-npc-draconid.html
@@ -19,105 +19,11 @@
         .npc-description { line-height: 1.7; opacity: 0.95; }
         .npc-quote { background: rgba(128, 128, 128, 0.1); border-left: 3px solid #808080; padding: 1rem; margin: 1rem 0; font-style: italic; opacity: 0.9; }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-dwarves.html
+++ b/docs/codex/lore-npc-dwarves.html
@@ -76,105 +76,11 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-elves.html
+++ b/docs/codex/lore-npc-elves.html
@@ -76,105 +76,11 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-emergent.html
+++ b/docs/codex/lore-npc-emergent.html
@@ -19,105 +19,11 @@
         .npc-description { line-height: 1.7; opacity: 0.95; }
         .npc-quote { background: rgba(75, 0, 130, 0.1); border-left: 3px solid #4B0082; padding: 1rem; margin: 1rem 0; font-style: italic; opacity: 0.9; }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-exchange.html
+++ b/docs/codex/lore-npc-exchange.html
@@ -76,105 +76,11 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-nomads.html
+++ b/docs/codex/lore-npc-nomads.html
@@ -76,105 +76,11 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-ossuarium.html
+++ b/docs/codex/lore-npc-ossuarium.html
@@ -76,105 +76,11 @@
             opacity: 0.9;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npc-wyrd.html
+++ b/docs/codex/lore-npc-wyrd.html
@@ -19,105 +19,11 @@
         .npc-description { line-height: 1.7; opacity: 0.95; }
         .npc-quote { background: rgba(186, 85, 211, 0.1); border-left: 3px solid #BA55D3; padding: 1rem; margin: 1rem 0; font-style: italic; opacity: 0.9; }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore-factions-overview.html" target="_parent">FACTIONS</a> /

--- a/docs/codex/lore-npcs.html
+++ b/docs/codex/lore-npcs.html
@@ -71,105 +71,11 @@
             line-height: 1.5;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-pre-sundering.html
+++ b/docs/codex/lore-pre-sundering.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-settlements.html
+++ b/docs/codex/lore-settlements.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-soul-binding.html
+++ b/docs/codex/lore-soul-binding.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-soul-economics.html
+++ b/docs/codex/lore-soul-economics.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-soulstone-system.html
+++ b/docs/codex/lore-soulstone-system.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-soulstone-volatility.html
+++ b/docs/codex/lore-soulstone-volatility.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-species-demographics.html
+++ b/docs/codex/lore-species-demographics.html
@@ -59,64 +59,10 @@
         }
 
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-sundering.html
+++ b/docs/codex/lore-sundering.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-theslar-overview.html
+++ b/docs/codex/lore-theslar-overview.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-void.html
+++ b/docs/codex/lore-void.html
@@ -7,47 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Interactive scroll reveal effects */
+/* Interactive scroll reveal effects */
         .reveal-section {
             opacity: 0;
             transform: translateY(30px);
@@ -72,21 +32,7 @@
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-world-map.html
+++ b/docs/codex/lore-world-map.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore-year-zero.html
+++ b/docs/codex/lore-year-zero.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="lore.html" target="_parent">LORE</a> /

--- a/docs/codex/lore.html
+++ b/docs/codex/lore.html
@@ -7,52 +7,7 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .lore-grid {
+.lore-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 2rem;
@@ -113,22 +68,7 @@
     </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="index.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             Lore Index

--- a/docs/codex/mission-cardinal-sin.html
+++ b/docs/codex/mission-cardinal-sin.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/mission-ironlord-thrain.html
+++ b/docs/codex/mission-ironlord-thrain.html
@@ -8,64 +8,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/mission-rot-lord.html
+++ b/docs/codex/mission-rot-lord.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="campaign.html" target="_parent">CAMPAIGN</a> /

--- a/docs/codex/nomads_mechanic.html
+++ b/docs/codex/nomads_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-nomads.html">Nomads Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-nomads.html" target="_parent">NOMADS</a> /

--- a/docs/codex/ossuarium_mechanic.html
+++ b/docs/codex/ossuarium_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-undead.html">Ossuarium Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-            <a href="wyrd_mechanic.html">Wyrd</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-undead.html" target="_parent">OSSUARIUM</a> /

--- a/docs/codex/player-aid-reference-card.html
+++ b/docs/codex/player-aid-reference-card.html
@@ -94,105 +94,11 @@
             }
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rulebook-pdf-viewer.html
+++ b/docs/codex/rulebook-pdf-viewer.html
@@ -340,64 +340,10 @@
             background: var(--border-gold);
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <!-- PDF-style navigation bar -->
+<!-- PDF-style navigation bar -->
     <div class="pdf-nav">
         <h1>📖 Penance: Core Rulebook</h1>
         <div class="pdf-nav-buttons">

--- a/docs/codex/rules-casket-classes.html
+++ b/docs/codex/rules-casket-classes.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-combat-flowchart.html
+++ b/docs/codex/rules-combat-flowchart.html
@@ -122,105 +122,11 @@
             }
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-combat.html
+++ b/docs/codex/rules-combat.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-common-mistakes.html
+++ b/docs/codex/rules-common-mistakes.html
@@ -80,105 +80,11 @@
             border-left: 3px solid var(--aged-gold);
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-component-damage.html
+++ b/docs/codex/rules-component-damage.html
@@ -7,64 +7,10 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-deck-construction.html
+++ b/docs/codex/rules-deck-construction.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-dice-pool.html
+++ b/docs/codex/rules-dice-pool.html
@@ -7,64 +7,10 @@
  <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="content" role="main">
+<main class="content" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="#v3-optional">v3.0 OPTIONAL</a> /

--- a/docs/codex/rules-dice.html
+++ b/docs/codex/rules-dice.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-quick-ref.html
+++ b/docs/codex/rules-quick-ref.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-range-los.html
+++ b/docs/codex/rules-range-los.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-scrap-cards.html
+++ b/docs/codex/rules-scrap-cards.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-soulstone-energy.html
+++ b/docs/codex/rules-soulstone-energy.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-support-as-main.html
+++ b/docs/codex/rules-support-as-main.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-taint-exploitation.html
+++ b/docs/codex/rules-taint-exploitation.html
@@ -24,64 +24,10 @@
  background: linear-gradient(to bottom, var(--dark-red), var(--blood-red)) !important;
  }
          /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="content" role="main">
+<main class="content" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="#v3-optional">v3.0 OPTIONAL</a> /

--- a/docs/codex/rules-terrain.html
+++ b/docs/codex/rules-terrain.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-thread-snap.html
+++ b/docs/codex/rules-thread-snap.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-turn-structure.html
+++ b/docs/codex/rules-turn-structure.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="rules.html" target="_parent">RULES</a> /

--- a/docs/codex/rules-v3-optional.html
+++ b/docs/codex/rules-v3-optional.html
@@ -27,105 +27,11 @@
             padding-top: 0;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="#core-rules">CORE RULES</a> /

--- a/docs/codex/rules.html
+++ b/docs/codex/rules.html
@@ -6,52 +6,7 @@
     <title>Rules Index - Penance Codex</title>
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        .rules-grid {
+.rules-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 2rem;
@@ -105,20 +60,7 @@
     </style>
 </head>
 <body>
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="index.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             Rules Index

--- a/docs/codex/scenario-boss-iron-saint.html
+++ b/docs/codex/scenario-boss-iron-saint.html
@@ -115,105 +115,11 @@
  text-transform: uppercase;
  }
          /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-escort-duty.html
+++ b/docs/codex/scenario-escort-duty.html
@@ -7,105 +7,11 @@
  <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-example-of-play.html
+++ b/docs/codex/scenario-example-of-play.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-king-of-the-hill.html
+++ b/docs/codex/scenario-king-of-the-hill.html
@@ -7,105 +7,11 @@
  <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-proving-grounds.html
+++ b/docs/codex/scenario-proving-grounds.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-reliquary-ruins.html
+++ b/docs/codex/scenario-reliquary-ruins.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-sabotage-mission.html
+++ b/docs/codex/scenario-sabotage-mission.html
@@ -7,105 +7,11 @@
  <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
- <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/scenario-tutorial-energy-threads.html
+++ b/docs/codex/scenario-tutorial-energy-threads.html
@@ -50,105 +50,11 @@
             min-width: 120px;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="scenarios.html">SCENARIOS</a> /

--- a/docs/codex/scenarios.html
+++ b/docs/codex/scenarios.html
@@ -7,105 +7,11 @@
     <link rel="stylesheet" href="manuscript-style.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="manuscript-page" role="main">
+<main class="manuscript-page" role="main">
  <nav class="breadcrumb" aria-label="Breadcrumb">
  <a href="index.html" target="_parent">CODEX</a> /
  <a href="scenarios.html" target="_parent">SCENARIOS</a> /

--- a/docs/codex/support-equipment.html
+++ b/docs/codex/support-equipment.html
@@ -325,65 +325,11 @@
             display: inline-block;
             margin-bottom: 1rem;
         }
-            /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+            
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <div class="breadcrumb" style="position: fixed; top: 10px; left: 10px; background: rgba(26,20,16,0.9); padding: 0.5rem 1rem; border-radius: 4px; z-index: 1000;">
+<div class="breadcrumb" style="position: fixed; top: 10px; left: 10px; background: rgba(26,20,16,0.9); padding: 0.5rem 1rem; border-radius: 4px; z-index: 1000;">
     <a href="content-home.html" target="_parent" style="color: #d4c5b0; text-decoration: none;">CODEX</a> /
     <a href="#rules" style="color: #d4c5b0; text-decoration: none;">RULES</a> /
     <span style="color: #b8956a;">Support Equipment</span>
@@ -401,8 +347,7 @@
             </div>
             <div style="display: flex; gap: 1rem;">
                 <a href="../cards/index.html" class="btn-nav">Card Database</a>
-                <a href="index.html" class="btn-nav">← Return to Codex</a>
-            </div>
+                </div>
         </div>
     </div>
 

--- a/docs/codex/support-units.html
+++ b/docs/codex/support-units.html
@@ -179,105 +179,11 @@
             color: #fff;
         }
             /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-        /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
+/* Navigation bar for direct page access (not in iframe) */
 </style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="#equipment">EQUIPMENT</a> /

--- a/docs/codex/wyrd_mechanic.html
+++ b/docs/codex/wyrd_mechanic.html
@@ -8,77 +8,10 @@
     <link rel="stylesheet" href="components.css">
     <style>
         /* Navigation bar for direct page access (not in iframe) */
-        .codex-nav {
-            display: none;
-            background: linear-gradient(135deg, #2b1f17 0%, #1a1410 100%);
-            border-bottom: 2px solid var(--aged-gold);
-            padding: 0.75rem 1.5rem;
-            position: sticky;
-            top: 0;
-            z-index: 1000;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.5);
-        }
-        .codex-nav-content {
-            max-width: 1400px;
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .codex-nav a {
-            color: var(--aged-gold);
-            text-decoration: none;
-            font-family: 'Cinzel', serif;
-            font-size: 0.9rem;
-            font-weight: 600;
-            letter-spacing: 0.05em;
-            transition: color 0.3s;
-            white-space: nowrap;
-        }
-        .codex-nav a:hover {
-            color: var(--parchment);
-        }
-        .codex-nav .nav-home {
-            color: var(--dark-red);
-            font-weight: 700;
-        }
-        .codex-nav .nav-separator {
-            color: var(--medium-brown);
-            margin: 0 0.25rem;
-        }
-
-    </style>
+</style>
 </head>
 <body>
-    <!-- Navigation bar (only shows when page opened directly, not in iframe) -->
-    <nav class="codex-nav" id="codexNav">
-        <div class="codex-nav-content">
-            <a href="index.html" class="nav-home">← Return to Codex</a>
-            <span class="nav-separator">|</span>
-            <a href="content-home.html">Home</a>
-            <span class="nav-separator">|</span>
-            <a href="faction-fae.html">Wyrd Conclave Overview</a>
-            <span class="nav-separator">|</span>
-            <span style="opacity: 0.6;">Other Mechanics:</span>
-            <a href="church_mechanic.html">Church</a>
-            <a href="dwarves_mechanic.html">Dwarves</a>
-            <a href="ossuarium_mechanic.html">Ossuarium</a>
-            <a href="elves_mechanic.html">Elves</a>
-            <a href="nomads_mechanic.html">Nomads</a>
-            <a href="exchange_mechanic.html">Exchange</a>
-            <a href="bloodlines_mechanic.html">Bloodlines</a>
-            <a href="emergent_mechanic.html">Emergent</a>
-            <a href="crucible_mechanic.html">Crucible</a>
-        </div>
-    </nav>
-    <script>
-        // Show navigation only if page is NOT in an iframe
-        if (window.self === window.top) {
-            document.getElementById('codexNav').style.display = 'block';
-        }
-    </script>
-    <main class="content" role="main">
+<main class="content" role="main">
         <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" target="_parent">CODEX</a> /
             <a href="faction-fae.html" target="_parent">WYRD CONCLAVE</a> /


### PR DESCRIPTION
Removed header navigation bars and footer navigation links from 113 codex HTML files. These elements were redundant with the existing breadcrumb navigation (CODEX / Category / File) at the top of each page.

Changes include:
- Removed <nav class="codex-nav"> header navigation blocks and associated JavaScript
- Removed associated .codex-nav CSS styles
- Removed footer "Return to Codex" links and buttons
- Cleaned up empty container divs left behind

All pages now rely solely on the breadcrumb navigation for consistency and simplicity.